### PR TITLE
Ensure counters initialize with existing songs

### DIFF
--- a/Osufy.user.js
+++ b/Osufy.user.js
@@ -85,6 +85,10 @@
       });
       observer.observe(songsContainer, { childList: true, subtree: true });
     }
+    // Update counters once after setup to reflect any existing songs
+    if (document.getElementById("maps-count")) {
+      updateCounters();
+    }
   }
 
   // Initialize when DOM is ready


### PR DESCRIPTION
## Summary
- Update counter initialization so song counts reflect existing elements on load
- Skip update when counters have not yet been created

## Testing
- `node --check Osufy.user.js`


------
https://chatgpt.com/codex/tasks/task_e_68a22fb04ee8832b860a1b88cb064397